### PR TITLE
Add policy resolver hook

### DIFF
--- a/src/xades/policy.py
+++ b/src/xades/policy.py
@@ -135,7 +135,7 @@ class Policy(object):
             TransformUsageDigestMethod[data['DigestMethodAlgorithm']])
         hash_calc.update(value)
         digest_val = hash_calc.digest()
-        assert data['DigestValue'].encode() == b64encode(digest_val)
+        assert data['DigestValue'] == b64encode(digest_val).decode()
 
     def calculate_certificates(self, node, key_x509):
         self.calculate_certificate(node, key_x509)
@@ -200,8 +200,8 @@ class Policy(object):
             assert b64encode(
                 parsed_x509.fingerprint(MAP_HASHLIB[digest.find(
                     'ds:DigestMethod', namespaces=NS_MAP
-                ).get('Algorithm')]())) == digest.find(
-                'ds:DigestValue', namespaces=NS_MAP).text.encode()
+                ).get('Algorithm')]())).decode() == digest.find(
+                'ds:DigestValue', namespaces=NS_MAP).text
 
     def calculate_policy_node(self, node, sign=False):
         """
@@ -287,7 +287,7 @@ class GenericPolicyId(Policy):
             ),
             ETSI.SigPolicyHash(
                 DS.DigestMethod(Algorithm=self.hash_method),
-                DS.DigestValue(b64encode(hash_calc.digest()))
+                DS.DigestValue(b64encode(hash_calc.digest()).decode())
             )
         )
         node.append(_ETSI_SignaturePolicyId)
@@ -308,5 +308,4 @@ class GenericPolicyId(Policy):
         hash_calc = hashlib.new(
             TransformUsageDigestMethod[data['DigestMethodAlgorithm']])
         hash_calc.update(value)
-        digest_val = hash_calc.digest()
-        assert data['DigestValue'].encode() == b64encode(digest_val)
+        assert data['DigestValue'] == b64encode(hash_calc.digest()).decode()

--- a/src/xades/policy.py
+++ b/src/xades/policy.py
@@ -29,23 +29,25 @@ ETSI = ElementMaker(namespace=EtsiNS)
 DS = ElementMaker(namespace=DSigNs)
 
 
-class Policy(object):
+class BasePolicy(object):
     """"
-    Policy class created in order to define different policies
+    Policy base class created in order to define different policies.
+    A mixture of base class implementations, and abstract class
+    interface definitions. (TODO: might be separated in the future)
     """
     hash_method = None
 
     @property
     def identifier(self):
-        raise Exception("Id is not defined")
+        raise NotImplementedError("Implement on specific subclasses")
 
     @property
     def name(self):
-        raise Exception("Name is not defined")
+        raise NotImplementedError("Implement on specific subclasses")
 
     @property
     def policy(self):
-        raise Exception("Policy is not defined")
+        raise NotImplementedError("Implement on specific subclasses")
 
     def _resolve_policy(self, identifier):
         """
@@ -120,22 +122,12 @@ class Policy(object):
 
     def validate_policy_node(self, node):
         """
-        An unspecific validation implementation for a given
+        A validation implementation for a given
         <etsi:SignaturePolicyIdentifier/> node
         :param node: Policy node
         :return: bool
         """
-        implied = node.find('etsi:SignaturePolicyImplied', namespaces=NS_MAP)
-        if implied is not None:
-            return
-        data = self._query_signature_policy_identifer_data(node)
-        value = self._resolve_policy(data['Identifier'])
-        value = self.set_transforms(data['Transforms'], value, False)
-        hash_calc = hashlib.new(
-            TransformUsageDigestMethod[data['DigestMethodAlgorithm']])
-        hash_calc.update(value)
-        digest_val = hash_calc.digest()
-        assert data['DigestValue'] == b64encode(digest_val).decode()
+        raise NotImplementedError("Implement on specific subclasses")
 
     def calculate_certificates(self, node, key_x509):
         self.calculate_certificate(node, key_x509)
@@ -218,7 +210,7 @@ class Policy(object):
         return self.produce_policy_node(node)
 
 
-class ImpliedPolicy(Policy):
+class ImpliedPolicy(BasePolicy):
     def __init__(self, hash_method=TransformSha1):
         self.hash_method = hash_method
 
@@ -245,7 +237,7 @@ class ImpliedPolicy(Policy):
         return
 
 
-class GenericPolicyId(Policy):
+class GenericPolicyId(BasePolicy):
     def __init__(self, identifier, name, hash_method):
         self.generic_identifier = identifier
         self.generic_name = name

--- a/src/xades/xades_context.py
+++ b/src/xades/xades_context.py
@@ -121,16 +121,16 @@ class XAdESContext(SignatureContext):
             'etsi:SigningCertificate', namespaces=NS_MAP
         )
         assert certificate_list is not None
-        if sign:
-            self.policy.calculate_certificates(certificate_list, self.x509)
-        else:
-            self.policy.validate_certificate(certificate_list, node)
         policy = signature_properties.find(
             'etsi:SignaturePolicyIdentifier', namespaces=NS_MAP
         )
         if sign:
             assert policy is not None
-        self.policy.calculate_policy_node(policy, sign)
+            self.policy.calculate_certificates(certificate_list, self.x509)
+            self.policy.produce_policy_node(policy)
+        else:
+            self.policy.validate_certificate(certificate_list, node)
+            self.policy.validate_policy_node(policy)
 
     def calculate_data_object_properties(
             self, data_object_properties, node, sign=False):


### PR DESCRIPTION
It commonly occurs that policy resolution does not involve
http, eg. in case of local caching.
This commit introduces a hook to implement custom resolvers.
It also polishes naming as required by this implementation.